### PR TITLE
Repositories api

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -50,7 +50,7 @@ shards:
 
   engine-driver:
     github: aca-labs/crystal-engine-driver
-    commit: 6c107d4530d0b75bceafab4e24033749e7824e10
+    commit: 3c72ac508839603b430eea809591ff05516746ab
 
   engine-drivers:
     github: aca-labs/crystal-engine-drivers
@@ -58,7 +58,7 @@ shards:
 
   engine-models:
     github: aca-labs/crystal-engine-models
-    commit: d62c94308e06295082562244d969502279bc9b0e
+    commit: ab16126e8e4e9b9b2c8eb344a80f4be4a2520e4a
 
   etcd:
     github: aca-labs/crystal-etcd
@@ -82,7 +82,7 @@ shards:
 
   hound-dog:
     github: aca-labs/hound-dog
-    commit: e6a5590ab2c71cd8f3569b43768d8035d9314ba4
+    commit: 080cb2eb7dfd70438ac8b231ba46beb184e79298
 
   ipaddress:
     github: Sija/ipaddress.cr
@@ -134,7 +134,7 @@ shards:
 
   rendezvous-hash:
     github: caspiano/rendezvous-hash
-    version: 0.2.1
+    version: 0.2.2
 
   rethinkdb-orm:
     github: spider-gazelle/rethinkdb-orm

--- a/shard.lock
+++ b/shard.lock
@@ -46,7 +46,7 @@ shards:
 
   engine-core:
     github: aca-labs/crystal-engine-core
-    commit: f53f7841acf585f8a6170538c618237f2129d7c9
+    commit: 92c1bf4b58bdfc3d368394a702b7f09f557190ff
 
   engine-driver:
     github: aca-labs/crystal-engine-driver

--- a/shard.lock
+++ b/shard.lock
@@ -34,7 +34,7 @@ shards:
 
   cron_parser:
     github: kostya/cron_parser
-    version: 0.2.0
+    version: 0.3.0
 
   crystal-rethinkdb:
     github: kingsleyh/crystal-rethinkdb
@@ -46,11 +46,11 @@ shards:
 
   engine-core:
     github: aca-labs/crystal-engine-core
-    commit: 92c1bf4b58bdfc3d368394a702b7f09f557190ff
+    commit: e9cb330eb52d234ff2f3745cd3c919a1e84b6bfc
 
   engine-driver:
     github: aca-labs/crystal-engine-driver
-    commit: 3c72ac508839603b430eea809591ff05516746ab
+    commit: 8a42b8d7bac0a22b7a6cf8b9b6b03ef4d06ac221
 
   engine-drivers:
     github: aca-labs/crystal-engine-drivers

--- a/src/controllers/drivers.cr
+++ b/src/controllers/drivers.cr
@@ -59,8 +59,7 @@ module ACAEngine::Api
     ###########################################################################
 
     def current_driver : Model::Driver
-      return @driver.as(Model::Driver) if @driver
-      find_driver
+      @driver || find_driver
     end
 
     def find_driver

--- a/src/controllers/modules.cr
+++ b/src/controllers/modules.cr
@@ -254,8 +254,7 @@ module ACAEngine::Api
     end
 
     def current_module : Model::Module
-      return @module.as(Model::Module) if @module
-      find_module
+      @module || find_module
     end
 
     def find_module

--- a/src/controllers/repositories.cr
+++ b/src/controllers/repositories.cr
@@ -1,0 +1,55 @@
+require "./application"
+
+module ACAEngine::Api
+  class Repositories < Application
+    base "/api/engine/v2/repositories/"
+
+    before_action :check_admin, except: [:index, :show]
+    before_action :check_support, only: [:index, :show]
+
+    before_action :find_repo, only: [:show, :update, :destroy]
+
+    @repo : Model::Repository?
+
+    def index
+      elastic = Model::Repository.elastic
+      query = elastic.query(params)
+      query.sort(NAME_SORT_ASC)
+      render json: elastic.search(query)
+    end
+
+    def show
+      render json: current_repo
+    end
+
+    def update
+      repo = current_repo
+      repo.assign_attributes_from_json(request.body.as(IO))
+
+      # Must destroy and re-add to change uri
+      render :unprocessable_entity, text: "Error: uri must not change" if repo.uri_changed?
+      save_and_respond repo
+    end
+
+    def create
+      save_and_respond(Model::Repository.from_json(request.body.as(IO)))
+    end
+
+    def destroy
+      current_repo.destroy
+      head :ok
+    end
+
+    #  Helpers
+    ###########################################################################
+
+    def current_repo : Model::Repository
+      @repo || find_repo
+    end
+
+    def find_repo
+      # Find will raise a 404 (not found) if there is an error
+      @repo = Model::Repository.find!(params["id"]?)
+    end
+  end
+end

--- a/src/controllers/repositories.cr
+++ b/src/controllers/repositories.cr
@@ -62,6 +62,21 @@ module ACAEngine::Api
       render json: core_client.driver(file_name, reporitory, number_of_commits)
     end
 
+    get "/:id/details", :commits do
+      reporitory = current_repo.folder_name.not_nil!
+      driver = params["driver"]
+      commit = params["commit"]
+
+      # Request to core:
+      # "/api/core/v1/drivers/#{file_name}/details?repository=#{reporitory}&count=#{number_of_commits}"
+      # Returns: `[{commit:, date:, author:, subject:}]`
+      core_client = Api::Systems.core_for(driver, logger.request_id)
+
+      # The raw JSON string is returned
+      response.headers["Content-Type"] = "application/json"
+      render text: core_client.driver_details(driver, commit, reporitory)
+    end
+
     #  Helpers
     ###########################################################################
 

--- a/src/controllers/settings.cr
+++ b/src/controllers/settings.cr
@@ -52,8 +52,7 @@ module ACAEngine::Api
     ###########################################################################
 
     def current_settings : Model::Settings
-      return @settings.as(Model::Settings) if @settings
-      find_settings
+      @settings || find_settings
     end
 
     def find_settings

--- a/src/controllers/system-triggers.cr
+++ b/src/controllers/system-triggers.cr
@@ -133,8 +133,7 @@ module ACAEngine::Api
     end
 
     def current_sys_trig : Model::TriggerInstance
-      return @sys_trig.as(Model::TriggerInstance) if @sys_trig
-      find_sys_trig
+      @sys_trig || find_sys_trig
     end
 
     def find_sys_trig

--- a/src/controllers/systems.cr
+++ b/src/controllers/systems.cr
@@ -310,8 +310,7 @@ module ACAEngine::Api
     end
 
     def current_system : Model::ControlSystem
-      return @control_system.as(Model::ControlSystem) if @control_system
-      find_system
+      @control_system || find_system
     end
 
     def find_system

--- a/src/controllers/triggers.cr
+++ b/src/controllers/triggers.cr
@@ -43,8 +43,7 @@ module ACAEngine::Api
     ###########################################################################
 
     def current_trigger
-      return @trig.as(Model::Trigger) if @trig
-      find_trigger
+      @trig || find_trigger
     end
 
     def find_trigger

--- a/src/controllers/users.cr
+++ b/src/controllers/users.cr
@@ -81,14 +81,12 @@ module ACAEngine::Api
     # end
 
     protected def find_user
-      @user = Model::User.find!(params["id"]?) unless @user
+      @user || (@user = Model::User.find!(params["id"]?))
     end
 
     protected def check_authorization
-      find_user unless @user
-
       # Does the current user have permission to perform the current action
-      head :forbidden unless (@user.try &.id) == current_user.id || is_admin?
+      head :forbidden unless (find_user.try &.id) == current_user.id || is_admin?
     end
   end
 end

--- a/src/controllers/zones.cr
+++ b/src/controllers/zones.cr
@@ -132,8 +132,7 @@ module ACAEngine::Api
     ###########################################################################
 
     def current_zone : Model::Zone
-      return @zone.as(Model::Zone) if @zone
-      find_zone
+      @zone || find_zone
     end
 
     def find_zone


### PR DESCRIPTION
Needs a spec, we'll need this for backoffice

@MrYuion in the latest version of Engine the driver repositories can be added to the database. So we need to be able to administer the driver git repos that are available in backoffice:

This is the data model / fields in the table
https://github.com/aca-labs/crystal-engine-models/blob/master/src/engine-models/repository.cr